### PR TITLE
IAAS-3376: Expose Jira issue metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 3.2.1-algolia.5
+- Add issue type and status category metadata to Jira issue output, and issue type metadata to
+  linked issue output.
+
 ## 3.2.1
 - Fixed the deafult attribute invocation for jira field ``description`` to verify that the attribute exists first. If ``description`` attribute does not exist then return ``null``.
 

--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -28,6 +28,9 @@ def to_issue_dict(issue, include_comments=False, include_attachments=False,
     else:
         assignee = None
 
+    issue_type = getattr(issue.fields, 'issuetype', None)
+    status_category = getattr(issue.fields.status, 'statusCategory', None)
+
     result = {
         'id': issue.id,
         'key': issue.key,
@@ -35,6 +38,8 @@ def to_issue_dict(issue, include_comments=False, include_attachments=False,
         'summary': issue.fields.summary,
         'description': issue.fields.description if hasattr(issue.fields, 'description') else None,
         'status': issue.fields.status.name,
+        'issue_type': issue_type.name if issue_type else None,
+        'status_category': status_category.name if status_category else None,
         'priority': issue.fields.priority.name if hasattr(issue.fields, 'priority') else None,
         'resolution': resolution,
         'labels': issue.fields.labels if hasattr(issue.fields, 'labels') else [],
@@ -129,15 +134,20 @@ def to_links_dict(issue):
     """
     :rtype: ``dict``
     """
+    outward_issue = issue.raw.get('outwardIssue')
+    linked_issue = outward_issue or issue.raw.get('inwardIssue') or {}
+    fields = linked_issue.get('fields') or {}
+    status = fields.get('status') or {}
+    issue_type = fields.get('issuetype') or {}
+    link_type = issue.raw.get('type') or {}
+
     result = {
         'id': issue.raw.get('id'),
-        'key': issue.raw.get('outwardIssue', issue.raw.get('inwardIssue')).get('key'),
-        'summary': issue.raw.get('outwardIssue', issue.raw.get('inwardIssue'))
-        .get('fields').get('summary'),
-        'status': issue.raw.get('outwardIssue', issue.raw.get('inwardIssue')).get('fields')
-        .get('status').get('name'),
-        'type': issue.raw.get('type').get('outward') if issue.raw.get('outwardIssue')
-        else issue.raw.get('type').get('inward'),
+        'key': linked_issue.get('key'),
+        'summary': fields.get('summary'),
+        'status': status.get('name'),
+        'type': link_type.get('outward') if outward_issue else link_type.get('inward'),
+        'issue_type': issue_type.get('name'),
     }
     return result
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 3.2.1-algolia.4
+version: 3.2.1-algolia.5
 python_versions:
   - "3"
 author: StackStorm, Inc.

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,166 @@
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from lib.formatters import to_issue_dict, to_links_dict
+
+
+class FormattersTestCase(TestCase):
+    def test_to_issue_dict_with_metadata_on_additive_output(self):
+        fields = SimpleNamespace(
+            assignee=SimpleNamespace(displayName="Assignee"),
+            created="2026-07-29T10:00:00.000+0000",
+            description="Description",
+            issuetype=SimpleNamespace(name="Machine Wipe"),
+            labels=["wipe"],
+            priority=SimpleNamespace(name="High"),
+            reporter=SimpleNamespace(displayName="Reporter"),
+            resolution=SimpleNamespace(name="Done"),
+            resolutiondate="2026-07-30T10:00:00.000+0000",
+            status=SimpleNamespace(
+                name="Completed",
+                statusCategory=SimpleNamespace(name="Done"),
+            ),
+            summary="Wipe machine",
+            updated="2026-07-30T10:00:00.000+0000",
+        )
+        issue = SimpleNamespace(
+            fields=fields,
+            id="10001",
+            key="IAAS-1",
+            permalink=mock.Mock(
+                return_value="https://algolia.atlassian.net/browse/IAAS-1 - Wipe machine"
+            ),
+        )
+
+        result = to_issue_dict(issue)
+
+        self.assertEqual(
+            result,
+            {
+                "id": "10001",
+                "key": "IAAS-1",
+                "url": "https://algolia.atlassian.net/browse/IAAS-1",
+                "summary": "Wipe machine",
+                "description": "Description",
+                "status": "Completed",
+                "issue_type": "Machine Wipe",
+                "status_category": "Done",
+                "priority": "High",
+                "resolution": "Done",
+                "labels": ["wipe"],
+                "reporter": "Reporter",
+                "assignee": "Assignee",
+                "created_at": "2026-07-29T10:00:00.000+0000",
+                "updated_at": "2026-07-30T10:00:00.000+0000",
+                "resolved_at": "2026-07-30T10:00:00.000+0000",
+            },
+        )
+
+    def test_to_issue_dict_without_optional_metadata_on_null_output(self):
+        fields = SimpleNamespace(
+            assignee=None,
+            created="2026-07-29T10:00:00.000+0000",
+            description=None,
+            labels=[],
+            reporter=None,
+            resolution=None,
+            resolutiondate=None,
+            status=SimpleNamespace(name="Open"),
+            summary="Partial issue",
+            updated="2026-07-30T10:00:00.000+0000",
+        )
+        issue = SimpleNamespace(
+            fields=fields,
+            id="10002",
+            key="IAAS-2",
+            permalink=mock.Mock(
+                return_value="https://algolia.atlassian.net/browse/IAAS-2 - Partial issue"
+            ),
+        )
+
+        result = to_issue_dict(issue)
+
+        self.assertIsNone(result["issue_type"])
+        self.assertIsNone(result["status_category"])
+        self.assertEqual(result["status"], "Open")
+        self.assertEqual(result["summary"], "Partial issue")
+
+    def test_to_links_dict_with_outward_issue_type_on_preserved_output(self):
+        link = SimpleNamespace(
+            raw={
+                "id": "20001",
+                "outwardIssue": {
+                    "key": "IAAS-3",
+                    "fields": {
+                        "issuetype": {"name": "Machine Wipe"},
+                        "status": {"name": "To Do"},
+                        "summary": "Wipe machine",
+                    },
+                },
+                "type": {"inward": "is caused by", "outward": "causes"},
+            }
+        )
+
+        result = to_links_dict(link)
+
+        self.assertEqual(
+            result,
+            {
+                "id": "20001",
+                "key": "IAAS-3",
+                "summary": "Wipe machine",
+                "status": "To Do",
+                "type": "causes",
+                "issue_type": "Machine Wipe",
+            },
+        )
+
+    def test_to_links_dict_with_inward_issue_type_on_preserved_output(self):
+        link = SimpleNamespace(
+            raw={
+                "id": "20002",
+                "inwardIssue": {
+                    "key": "IAAS-4",
+                    "fields": {
+                        "issuetype": {"name": "Machine Wipe"},
+                        "status": {"name": "Done"},
+                        "summary": "Completed wipe",
+                    },
+                },
+                "type": {"inward": "is caused by", "outward": "causes"},
+            }
+        )
+
+        result = to_links_dict(link)
+
+        self.assertEqual(
+            result,
+            {
+                "id": "20002",
+                "key": "IAAS-4",
+                "summary": "Completed wipe",
+                "status": "Done",
+                "type": "is caused by",
+                "issue_type": "Machine Wipe",
+            },
+        )
+
+    def test_to_links_dict_without_optional_issue_type_on_null_output(self):
+        link = SimpleNamespace(
+            raw={
+                "id": "20003",
+                "outwardIssue": {
+                    "key": "IAAS-5",
+                    "fields": {
+                        "status": {"name": "To Do"},
+                        "summary": "Partial linked issue",
+                    },
+                },
+                "type": {"inward": "is caused by", "outward": "causes"},
+            }
+        )
+
+        result = to_links_dict(link)
+
+        self.assertIsNone(result["issue_type"])
+        self.assertEqual(result["type"], "causes")


### PR DESCRIPTION
**Requestor/Issue:** [IAAS-3376](https://algolia.atlassian.net/browse/IAAS-3376)

**Description/Why:**
StackStorm workflows need issue metadata to filter linked Machine Wipe tickets and check status categories without extra JQL searches.

**Output contract:**
- `jira.get_issue`, `jira.search_issues`, `jira.create_issue`, `jira.add_field_value`, and `jira.update_field_value` add `issue_type` and `status_category`. Missing metadata returns `null`.
- `jira.get_issue_links` adds `issue_type`. Missing issue type metadata returns `null`.
- The existing link `type` field remains the directional relationship, such as `causes` or `is caused by`.

[IAAS-3376]: https://algolia.atlassian.net/browse/IAAS-3376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ