### PR TITLE
IAAS-3455: Add idempotent Jira flag action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.3.0-algolia.2
+- Add an idempotent ``jira.flag_issue`` action for the Jira Flagged field.
+
 ## 3.3.0-algolia.1
 - Add issue type and status category metadata to Jira issue output, and issue type metadata to
   linked issue output.

--- a/actions/flag_issue.py
+++ b/actions/flag_issue.py
@@ -1,0 +1,14 @@
+from lib.base import BaseJiraAction
+
+
+class FlagIssue(BaseJiraAction):
+    def run(self, issue_key: str) -> dict:
+        issue = self._client.issue(issue_key)
+        flag_field = "customfield_10038"
+        flags = issue.raw["fields"].get(flag_field) or []
+
+        if any(flag.get("value") == "Impediment" for flag in flags):
+            return {"issue_key": issue_key, "flag_added": False}
+
+        issue.update(fields={flag_field: [{"value": "Impediment"}]})
+        return {"issue_key": issue_key, "flag_added": True}

--- a/actions/flag_issue.yaml
+++ b/actions/flag_issue.yaml
@@ -1,0 +1,11 @@
+---
+name: flag_issue
+runner_type: python-script
+description: Add the Jira Flagged value to an issue if it is not already present.
+enabled: true
+entry_point: flag_issue.py
+parameters:
+  issue_key:
+    type: string
+    description: Issue key (e.g. PROJECT-1000).
+    required: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 3.3.0-algolia.1
+version: 3.3.0-algolia.2
 python_versions:
   - "3"
 author: StackStorm, Inc.

--- a/tests/test_action_flag_issue.py
+++ b/tests/test_action_flag_issue.py
@@ -1,0 +1,48 @@
+import mock
+
+from flag_issue import FlagIssue
+
+
+CONFIG = {
+    "url": "https://company.atlassian.net",
+    "auth_method": "basic",
+    "username": "user",
+    "password": "passwd",
+    "verify": True,
+}
+
+
+def test_run_unflagged_issue_on_flag_added():
+    with mock.patch("lib.base.JIRA") as jira_class:
+        jira = jira_class.return_value
+        issue = mock.Mock(raw={"fields": {"customfield_10038": None}})
+        jira.issue.return_value = issue
+        action = FlagIssue(CONFIG)
+
+        result = action.run("IAAS-123")
+
+    issue.update.assert_called_once_with(
+        fields={"customfield_10038": [{"value": "Impediment"}]}
+    )
+    assert result == {"issue_key": "IAAS-123", "flag_added": True}
+
+
+def test_run_flagged_issue_on_already_present():
+    with mock.patch("lib.base.JIRA") as jira_class:
+        jira = jira_class.return_value
+        issue = mock.Mock(
+            raw={
+                "fields": {
+                    "customfield_10038": [
+                        {"id": "10019", "value": "Impediment"},
+                    ]
+                }
+            }
+        )
+        jira.issue.return_value = issue
+        action = FlagIssue(CONFIG)
+
+        result = action.run("IAAS-123")
+
+    issue.update.assert_not_called()
+    assert result == {"issue_key": "IAAS-123", "flag_added": False}


### PR DESCRIPTION
**Requestor/Issue:** IAAS-3455

**Description/Why:**
Machine Decommission and Machine Wipe now call `jira.flag_issue` when a ticket needs human attention. This adds the missing action without changing the Jira lifecycle status or clearing an existing flag.