### PR TITLE
IAAS-3035: Add Jira transition by target status

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.3.0-algolia.3
+- Add ``jira.transition_issue_by_status`` to transition an issue by its target status.
+
 ## 3.3.0-algolia.2
 - Add an idempotent ``jira.flag_issue`` action for the Jira Flagged field.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 3.3.0-algolia.3
-- Add ``jira.transition_issue_by_status`` to transition an issue by its target status.
+- Add ``jira.transition_issue_by_status`` to idempotently transition an issue by its target status.
 
 ## 3.3.0-algolia.2
 - Add an idempotent ``jira.flag_issue`` action for the Jira Flagged field.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The sensor monitors for new tickets and sends a trigger into the system whenever
 * ``bulk_link_issue`` - Link many JIRA issues to another JIRA issue.
 * ``comment_issue`` - Comment on a JIRA issue / ticket.
 * ``create_issue`` - Create a new JIRA issue / ticket.
+* ``flag_issue`` - Add the Jira Flagged value to an issue.
 * ``get_issue`` - Retrieve information about a particular JIRA issue.
 * ``get_issue_attachments`` - Retrieve attachments for a particular JIRA issue.
 * ``get_issue_comments`` - Retrieve comments for a particular JIRA issue.
@@ -130,6 +131,7 @@ The sensor monitors for new tickets and sends a trigger into the system whenever
 * ``search_issues`` - Search JIRA issues with a JQL query.
 * ``transition_issue`` - Do a transition on a JIRA issue / ticket.
 * ``transition_issue_by_name`` - Do a transition on a JIRA issue / ticket.
+* ``transition_issue_by_status`` - Transition a Jira issue to a target status.
 * ``update_field_value`` - Update a field in a particular JIRA issue.
 * ``add_gadget`` - Add a gadget to an existing JIRA dashboard.
 * ``copy_dashboard`` - Copy an existing JIRA dashboard

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The sensor monitors for new tickets and sends a trigger into the system whenever
 * ``search_issues`` - Search JIRA issues with a JQL query.
 * ``transition_issue`` - Do a transition on a JIRA issue / ticket.
 * ``transition_issue_by_name`` - Do a transition on a JIRA issue / ticket.
-* ``transition_issue_by_status`` - Transition a Jira issue to a target status.
+* ``transition_issue_by_status`` - Idempotently transition a Jira issue to a target status.
 * ``update_field_value`` - Update a field in a particular JIRA issue.
 * ``add_gadget`` - Add a gadget to an existing JIRA dashboard.
 * ``copy_dashboard`` - Copy an existing JIRA dashboard

--- a/actions/run.py
+++ b/actions/run.py
@@ -16,6 +16,9 @@ class ActionManager(BaseJiraAction):
                 del kwargs['transition_name']
             elif action == 'transition_issue_by_status':
                 status = kwargs.pop('status')
+                issue = self._client.issue(kwargs['issue'], fields='status')
+                if issue.fields.status.name == status:
+                    return (True, None)
                 transitions = [
                     transition for transition in self._client.transitions(kwargs['issue'])
                     if transition.get('to', {}).get('name') == status

--- a/actions/run.py
+++ b/actions/run.py
@@ -14,6 +14,19 @@ class ActionManager(BaseJiraAction):
                 action = 'transition_issue'
                 kwargs['transition'] = self.transition_name_to_id(**kwargs)
                 del kwargs['transition_name']
+            elif action == 'transition_issue_by_status':
+                status = kwargs.pop('status')
+                transitions = [
+                    transition for transition in self._client.transitions(kwargs['issue'])
+                    if transition.get('to', {}).get('name') == status
+                ]
+                if len(transitions) != 1:
+                    return (
+                        False,
+                        f'Expected one transition to status "{status}", found {len(transitions)}',
+                    )
+                action = 'transition_issue'
+                kwargs['transition'] = transitions[0]['id']
             return (True, getattr(self._client, action)(**kwargs))
         except JIRAError as error:
             return (False, str(error))

--- a/actions/transition_issue_by_status.yaml
+++ b/actions/transition_issue_by_status.yaml
@@ -1,0 +1,19 @@
+---
+name: transition_issue_by_status
+runner_type: python-script
+description: Transition a Jira issue to a target status.
+enabled: true
+entry_point: run.py
+parameters:
+  action:
+    default: transition_issue_by_status
+    immutable: true
+    type: string
+  issue:
+    type: string
+    description: Issue key (e.g. PROJECT-1000).
+    required: true
+  status:
+    type: string
+    description: Target status name (e.g. In Progress, Done).
+    required: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 3.3.0-algolia.2
+version: 3.3.0-algolia.3
 python_versions:
   - "3"
 author: StackStorm, Inc.

--- a/tests/test_action_run.py
+++ b/tests/test_action_run.py
@@ -68,6 +68,7 @@ class RunTestCase(JIRABaseActionTestCase):
 def test_transition_issue_by_status_single_match_on_transition_executed() -> None:
     action = ActionManager.__new__(ActionManager)
     action._client = mock.Mock()
+    action._client.issue.return_value.fields.status.name = 'To Do'
     action._client.transitions.return_value = [
         {'id': '11', 'name': 'Start Progress', 'to': {'name': 'In Progress'}},
         {'id': '21', 'name': 'Close', 'to': {'name': 'Done'}},
@@ -86,9 +87,27 @@ def test_transition_issue_by_status_single_match_on_transition_executed() -> Non
     )
 
 
+def test_transition_issue_by_status_target_status_on_noop_success() -> None:
+    action = ActionManager.__new__(ActionManager)
+    action._client = mock.Mock()
+    action._client.issue.return_value.fields.status.name = 'Done'
+
+    result = action.run(
+        action='transition_issue_by_status',
+        issue='IAAS-3035',
+        status='Done',
+    )
+
+    assert result == (True, None)
+    action._client.issue.assert_called_once_with('IAAS-3035', fields='status')
+    action._client.transitions.assert_not_called()
+    action._client.transition_issue.assert_not_called()
+
+
 def test_transition_issue_by_status_no_match_on_explicit_failure() -> None:
     action = ActionManager.__new__(ActionManager)
     action._client = mock.Mock()
+    action._client.issue.return_value.fields.status.name = 'To Do'
     action._client.transitions.return_value = []
 
     result = action.run(
@@ -104,6 +123,7 @@ def test_transition_issue_by_status_no_match_on_explicit_failure() -> None:
 def test_transition_issue_by_status_multiple_matches_on_explicit_failure() -> None:
     action = ActionManager.__new__(ActionManager)
     action._client = mock.Mock()
+    action._client.issue.return_value.fields.status.name = 'To Do'
     action._client.transitions.return_value = [
         {'id': '11', 'name': 'Resolve', 'to': {'name': 'Done'}},
         {'id': '21', 'name': 'Close', 'to': {'name': 'Done'}},

--- a/tests/test_action_run.py
+++ b/tests/test_action_run.py
@@ -63,3 +63,57 @@ class RunTestCase(JIRABaseActionTestCase):
         kwargs = {'issue': 'ISSUE-XX', 'transition_name': 'Done'}
         transition_id = action.transition_name_to_id(**kwargs)
         self.assertEqual(transition_id, None)
+
+
+def test_transition_issue_by_status_single_match_on_transition_executed() -> None:
+    action = ActionManager.__new__(ActionManager)
+    action._client = mock.Mock()
+    action._client.transitions.return_value = [
+        {'id': '11', 'name': 'Start Progress', 'to': {'name': 'In Progress'}},
+        {'id': '21', 'name': 'Close', 'to': {'name': 'Done'}},
+    ]
+
+    result = action.run(
+        action='transition_issue_by_status',
+        issue='IAAS-3035',
+        status='In Progress',
+    )
+
+    assert result == (True, action._client.transition_issue.return_value)
+    action._client.transition_issue.assert_called_once_with(
+        issue='IAAS-3035',
+        transition='11',
+    )
+
+
+def test_transition_issue_by_status_no_match_on_explicit_failure() -> None:
+    action = ActionManager.__new__(ActionManager)
+    action._client = mock.Mock()
+    action._client.transitions.return_value = []
+
+    result = action.run(
+        action='transition_issue_by_status',
+        issue='IAAS-3035',
+        status='Done',
+    )
+
+    assert result == (False, 'Expected one transition to status "Done", found 0')
+    action._client.transition_issue.assert_not_called()
+
+
+def test_transition_issue_by_status_multiple_matches_on_explicit_failure() -> None:
+    action = ActionManager.__new__(ActionManager)
+    action._client = mock.Mock()
+    action._client.transitions.return_value = [
+        {'id': '11', 'name': 'Resolve', 'to': {'name': 'Done'}},
+        {'id': '21', 'name': 'Close', 'to': {'name': 'Done'}},
+    ]
+
+    result = action.run(
+        action='transition_issue_by_status',
+        issue='IAAS-3035',
+        status='Done',
+    )
+
+    assert result == (False, 'Expected one transition to status "Done", found 2')
+    action._client.transition_issue.assert_not_called()


### PR DESCRIPTION
**Requestor/Issue:** IAAS-3035

**Description/Why:**
StackStorm workflows currently need transition names or IDs even when they only care about the target status. Add `jira.transition_issue_by_status` so workflows can transition by status, succeed without a transition when the issue is already in the target status, and fail when the route is missing or ambiguous.